### PR TITLE
Misc. config tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "jest": {
     "moduleNameMapper": {
-      "\\.(css|jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/src/__mocks__/fileMock.js"
+      "\\.(css|jpg|png|svg|woff|woff2)$": "<rootDir>/src/__mocks__/fileMock.js"
     }
   },
   "browserslist": [

--- a/package.json
+++ b/package.json
@@ -53,15 +53,9 @@
     }
   },
   "browserslist": [
-    "last 2 Chrome versions",
-    "last 2 ChromeAndroid versions",
-    "last 2 Firefox versions",
-    "last 2 FirefoxAndroid versions",
-    "last 2 Safari versions",
-    "last 2 iOS versions",
-    "last 2 Edge versions",
-    "last 2 Opera versions",
-    "last 2 OperaMobile versions"
+    ">0.2%",
+    "not dead",
+    "not op_mini all"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Updates the browserslist config to support a broader set of browsers.
  - Unfortunately, because of a bug in Parcel/Babel, this breaks things. See https://github.com/parcel-bundler/parcel/issues/1128#issuecomment-402570464. I am really annoyed at Parcel...
- Simplifies the Jest `moduleNameMapper` config to only include file types that are actually used.