### PR TITLE
Update homepage copy to make "view map" more obvious

### DIFF
--- a/src/WelcomeOverlay.js
+++ b/src/WelcomeOverlay.js
@@ -133,16 +133,11 @@ const WelcomeOverlay = ({ onClose }) => {
         />
       </div>
 
-      <div className="socialFooter">
+      <footer>
         <a
           href="https://instagram.com/babyintow/"
           target="_blank"
           rel="noopener noreferrer"
-          style={{
-            color: "white",
-            textDecoration: "none",
-            lineHeight: "20px"
-          }}
         >
           Follow us on Instagram
           <img
@@ -156,7 +151,7 @@ const WelcomeOverlay = ({ onClose }) => {
             alt="Instagram"
           />
         </a>
-      </div>
+      </footer>
     </div>
   );
 };

--- a/src/WelcomeOverlay.js
+++ b/src/WelcomeOverlay.js
@@ -34,7 +34,7 @@ const WelcomeOverlay = ({ onClose }) => {
             Curated by parents in your community
           </div>
           <button type="button" className="welcomePageButton" onClick={onClose}>
-            Get Started
+            View Map
           </button>
         </div>
       </div>
@@ -109,11 +109,9 @@ const WelcomeOverlay = ({ onClose }) => {
       >
         <div className="welcomeFooterContent">
           <div className="welcomeSectionParagraph">
-            We&apos;re a community of parents helping out other parents and
-            always on the hunt for more baby-friendly places to add to our map.
-          </div>
-          <div className="welcomeSectionParagraph">
-            Got a good tip to share? Let us know so we can share it with others.
+            We&apos;re a community of parents helping out other parents by
+            sharing tips on baby-friendly things to do in your community. Find
+            something new to explore today.
           </div>
           <button
             type="button"
@@ -123,9 +121,9 @@ const WelcomeOverlay = ({ onClose }) => {
               backgroundColor: "white",
               margin: "4px 0 20px 0"
             }}
-            onClick={() => window.open("https://forms.gle/yt38Z27Y3SE81q447")}
+            onClick={onClose}
           >
-            Submit Baby Tip
+            View Map
           </button>
         </div>
         <img

--- a/src/WelcomeOverlay.js
+++ b/src/WelcomeOverlay.js
@@ -141,7 +141,6 @@ const WelcomeOverlay = ({ onClose }) => {
         >
           Submit a baby tip
         </a>
-        &nbsp;|&nbsp;
         <a
           href="https://instagram.com/babyintow/"
           target="_blank"

--- a/src/WelcomeOverlay.js
+++ b/src/WelcomeOverlay.js
@@ -135,6 +135,14 @@ const WelcomeOverlay = ({ onClose }) => {
 
       <footer>
         <a
+          href="https://forms.gle/yt38Z27Y3SE81q447"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Submit a baby tip
+        </a>
+        &nbsp;|&nbsp;
+        <a
           href="https://instagram.com/babyintow/"
           target="_blank"
           rel="noopener noreferrer"

--- a/src/WelcomeOverlay.js
+++ b/src/WelcomeOverlay.js
@@ -156,7 +156,7 @@ const WelcomeOverlay = ({ onClose }) => {
               paddingBottom: "4px",
               verticalAlign: "middle"
             }}
-            alt="Instagram"
+            alt=""
           />
         </a>
       </footer>

--- a/src/style.css
+++ b/src/style.css
@@ -135,9 +135,12 @@ footer {
   padding: 20px 24px;
   text-align: center;
   line-height: 20px;
+  display: flex;
+  flex-direction: column;
 }
 
 footer > a {
+  margin: 4px 0;
   color: white; /* override default link style */
   text-decoration: none;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -223,10 +223,6 @@ footer > a {
     height: 380px;
     margin-left: 50px;
   }
-
-  footer {
-    padding: 20px 50px;
-  }
 }
 
 /* Filter controls */

--- a/src/style.css
+++ b/src/style.css
@@ -129,10 +129,17 @@ hr {
   height: 250px;
 }
 
-.socialFooter {
+footer {
+  color: white;
   background-color: black;
   padding: 20px 24px;
   text-align: center;
+  line-height: 20px;
+}
+
+footer > a {
+  color: white; /* override default link style */
+  text-decoration: none;
 }
 
 @media (min-width: 1000px) {
@@ -217,7 +224,7 @@ hr {
     margin-left: 50px;
   }
 
-  .socialFooter {
+  footer {
     padding: 20px 50px;
   }
 }


### PR DESCRIPTION
# Summary
Fixes: https://trello.com/c/KPKVEeev/156-updates-to-hp-reduce-drop-offs

# Detailed changes
- 45e9d8c8f1b4eff424a648a9499d2bd65841c9ad: changes the "Get Started" button copy to be "View Map", and changes the bottom "submit tip" section to have a second "View Map" button.
- c683ca3c001c543af0faea8fff1cc6c123afcbb3: uses a `<footer>` element for the footer, and moves some inline styling to the CSS file
- f7b544ea2b7ff113e351cd63d95128934c49d661: adds a "Submit tip" link to the footer to replace the removed section
- 5319f666af2a4294771473915942642c3b8a4bcd: don't specify an alt tag for the instagram icon since it is not semantically important (redundant with its label)