### PR TITLE
replace feedback link with 'submit tip' in map footer

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -205,16 +205,16 @@ const App = ({ locationId }) => {
           padding: "10px",
           backgroundColor: "#374B5B",
           color: "white",
+          textAlign: "center",
         }}
       >
-        Baby in Tow is currently in BETA.{" "}
         <a
           style={{ fontWeight: 600, color: "white" }}
-          href="https://forms.gle/X6Tswurfg5VP49Zs7"
+          href="https://forms.gle/yt38Z27Y3SE81q447"
           target="_blank"
           rel="noopener noreferrer"
         >
-          We&apos;d love your feedback!
+          Submit a baby tip
         </a>
       </div>
     </div>


### PR DESCRIPTION
Per [request from Christine](https://babyintow.slack.com/archives/CT4JX4WH1/p1582129979002200), replaces the "we'd like feedback" text at the bottom of the map with a "submit a tip" link:

![Screen Shot 2020-02-19 at 11 47 15](https://user-images.githubusercontent.com/327839/74854626-97855780-530d-11ea-8766-2f2bb6356778.png)
