### PR TITLE
configure Netlify to redirect all URLs to index.html SPA

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,6 +10,6 @@
 # The following redirect is intended for use with most SPAs that handle
 # routing internally.
 [[redirects]]
-  from = "/locations/*"
+  from = "/*"
   to = "/index.html"
   status = 200


### PR DESCRIPTION
#32 introduced a new route (https://babyintow.ca/map), but I noticed that loading it directly didn't work (404).

I realized that this was because only some routes were set to redirect to the `index.html` single-page app. This PR makes it so that all URLs point to `index.html`.